### PR TITLE
Add source-repository section to telegram.cabal

### DIFF
--- a/telegram.cabal
+++ b/telegram.cabal
@@ -22,3 +22,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
+
+Source-Repository head
+  Type:                git
+  Location:            https://github.com/sgillis/telegram


### PR DESCRIPTION
Hope this will also make the repository information show up on http://hackage.haskell.org/package/telegram

Had to search for your name to find the source here on Github.
